### PR TITLE
Removing PHP 7 warnings

### DIFF
--- a/fs_cdr.php
+++ b/fs_cdr.php
@@ -58,7 +58,12 @@ class fs_cdr extends fs_curl {
     /**
      * This is where we instantiate our parent and set up our CDR object
      */
-    public function fs_cdr() {
+
+	public function fs_cdr()	{
+        	self::__construct();
+    }
+
+    public function __construct() {
         $this->fs_curl();
         $this->cdr = stripslashes($this->request['cdr']);
         $this->xml_cdr = new SimpleXMLElement($this->cdr);

--- a/fs_chatplan.php
+++ b/fs_chatplan.php
@@ -18,6 +18,10 @@
 		private $special_class_file;
 
 		public function fs_chatplan() {
+        		self::__construct();
+    		}
+
+		public function  __construct() {
 			$this -> fs_curl();
 		}
 

--- a/fs_configuration.php
+++ b/fs_configuration.php
@@ -21,7 +21,13 @@ class fs_configuration extends fs_curl {
      * This method will instantiate all other objects upon which it relies.
      * @return void
     */
-    function fs_configuration() {
+
+    public function fs_dialplan()
+    {
+        self::__construct();
+    }
+
+    function  __construct() {
         $this -> fs_curl();
         $conf_file = $this->request['key_value'];
         $this->debug("RECEIVED REQUEST FOR $conf_file");

--- a/fs_curl.php
+++ b/fs_curl.php
@@ -51,7 +51,14 @@
 		 * in child classes
 		 * @return void
 		 */
-		public function fs_curl() {
+		
+		public function fs_curl()
+    		{
+       		 	self::__construct();
+    		}
+	
+		public function __construct() {
+		//public function fs_curl() {
 			openlog( 'fs_curl', LOG_NDELAY | LOG_PID, LOG_USER );
 			header( 'Content-Type: text/xml' );
 			$this->generate_request_array();

--- a/fs_dialplan.php
+++ b/fs_dialplan.php
@@ -18,7 +18,12 @@ if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)) {
 class fs_dialplan extends fs_curl {
     private $special_class_file;
 
-    public function fs_dialplan() {
+
+    public function fs_dialplan()
+    {
+        self::__construct();
+    }
+    public function __construct() {
         $this -> fs_curl();
     }
 

--- a/fs_directory.php
+++ b/fs_directory.php
@@ -26,6 +26,10 @@
 		private $users_gateway_params;
 
 		public function fs_directory() {
+        		self::__construct();
+    		}
+	
+		public function __construct() {
 			$this->fs_curl();
 			if ( array_key_exists( 'user', $this->request ) ) {
 				$this->user = $this->request['user'];

--- a/index.php
+++ b/index.php
@@ -10,8 +10,7 @@
 /**
  * define for the time that execution of the script started
  */
-define('START_TIME', ereg_replace('^0\.([0-9]+) ([0-9]+)$', '\2.\1', microtime()));
-
+define('START_TIME', preg_replace('/^0\.(\d+) (\d+)$/', '\2.\1', microtime()));
 /**
  * Pre-Class initialization die function
  * This function should be called on any


### PR DESCRIPTION
Running under php 7 the code generates warnings for  "Methods with the same name as their class will not be constructors in a future version of PHP" - see http://php.net/manual/en/migration70.deprecated.php

This quick update updates the code to use both PHP4 and PHP5 style constructors, but keeps the PHP4-style one for backwards compatibility.  Removes the warning and I'm assuming in the near future makes it easier to remove the php 4 style constructors.
